### PR TITLE
chore: add logging template to mount

### DIFF
--- a/app/include/mount/Mount.hpp
+++ b/app/include/mount/Mount.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef OPEN_ASTRO_FIRMWARE_MOUNT_MOUNT_HPP
+#define OPEN_ASTRO_FIRMWARE_MOUNT_MOUNT_HPP
 
 #include <inttypes.h>
 
@@ -35,3 +36,5 @@ public:
      */
     bool setTargetRa(unsigned int h, unsigned int m, unsigned int s);
 };
+
+#endif

--- a/app/src/mount/Kconfig
+++ b/app/src/mount/Kconfig
@@ -7,4 +7,8 @@ config MOUNT_THREAD_STACK_SIZE
         The size of the stack used by the mount thread.
         The default value is 0x4000 bytes (16kB).
 
+module = MOUNT
+module-str = mount
+source "subsys/logging/Kconfig.template.log_config"
+
 endmenu

--- a/app/src/mount/Mount.cpp
+++ b/app/src/mount/Mount.cpp
@@ -2,7 +2,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(Mount);
+LOG_MODULE_REGISTER(Mount, CONFIG_MOUNT_LOG_LEVEL);
 
 Mount::Mount() {
     LOG_DBG("creating Mount");


### PR DESCRIPTION
use Kconfig logging template in order to be able to control log-levels of mount class.